### PR TITLE
GLFW 3.3 (Scaling support)

### DIFF
--- a/src/glfw.re
+++ b/src/glfw.re
@@ -139,6 +139,11 @@ module Monitor = {
     width: int,
     height: int,
   };
+
+  type scale = {
+    xScale: float,
+    yScale: float,
+  }
 };
 
 module VideoMode = {
@@ -156,6 +161,8 @@ external glfwGetMonitorPos: Monitor.t => Monitor.position =
   "caml_glfwGetMonitorPos";
 external glfwGetMonitorPhysicalSize: Monitor.t => Monitor.dimensions =
   "caml_glfwGetMonitorPhysicalSize";
+external glfwGetMonitorContentScale: Monitor.t => Monitor.scale =
+  "caml_glfwGetMonitorContentScale";
 
 type windowHint =
   | GLFW_RESIZABLE

--- a/src/glfw.re
+++ b/src/glfw.re
@@ -42,6 +42,8 @@ external glfwSetWindowPos: (Window.t, int, int) => unit =
   "caml_glfwSetWindowPos";
 external glfwGetWindowSize: Window.t => Window.windowSize =
   "caml_glfwGetWindowSize";
+external glfwGetWindowContentScale: Window.t => Window.windowScale =
+  "caml_glfwGetWindowContentScale";
 external glfwGetFramebufferSize: Window.t => Window.frameBufferSize =
   "caml_glfwGetFramebufferSize";
 [@noalloc] external glfwShowWindow: Window.t => unit = "caml_glfwShowWindow";

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -71,6 +71,11 @@ module Monitor: {
     width: int,
     height: int,
   };
+
+  type scale = {
+    xScale: float,
+    yScale: float,
+  }
 };
 
 module VideoMode: {
@@ -84,6 +89,7 @@ let glfwGetPrimaryMonitor: unit => Monitor.t;
 let glfwGetVideoMode: Monitor.t => VideoMode.t;
 let glfwGetMonitorPos: Monitor.t => Monitor.position;
 let glfwGetMonitorPhysicalSize: Monitor.t => Monitor.dimensions;
+let glfwGetMonitorContentScale: Monitor.t => Monitor.scale;
 
 type windowHint =
   | GLFW_RESIZABLE

--- a/src/glfw.rei
+++ b/src/glfw.rei
@@ -16,6 +16,7 @@ let glfwSetWindowPos: (Window.t, int, int) => unit;
 let glfwSetWindowSize: (Window.t, int, int) => unit;
 let glfwGetFramebufferSize: Window.t => Window.frameBufferSize;
 let glfwGetWindowSize: Window.t => Window.windowSize;
+let glfwGetWindowContentScale: Window.t => Window.windowScale;
 let glfwMaximizeWindow: Window.t => unit;
 let glfwSetWindowTitle: (Window.t, string) => unit;
 let glfwShowWindow: Window.t => unit;

--- a/src/glfw_types.re
+++ b/src/glfw_types.re
@@ -10,6 +10,11 @@ module Window = {
     width: int,
     height: int,
   };
+
+  type windowScale = {
+    xScale: float,
+    yScale: float
+  }
 };
 
 module NativeWindow = {

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -626,8 +626,8 @@ extern "C" {
         CAMLlocal1(ret);
         WindowInfo* pWindowInfo = (WindowInfo *)vWindow;
 
-        double xScale, yScale;
-        glfwGetWindowContentScale(pWindowInfo->pWindow, (float*) &xScale, (float*) &yScale);
+        float xScale, yScale;
+        glfwGetWindowContentScale(pWindowInfo->pWindow, &xScale, &yScale);
 
         ret = caml_alloc(2 * Double_wosize, Double_array_tag);
         Store_double_field(ret, 0, xScale);
@@ -643,8 +643,8 @@ extern "C" {
         CAMLlocal1(ret);
         GLFWmonitor* pMonitor = (GLFWmonitor*)vMonitor;
 
-        double xScale, yScale;
-        glfwGetMonitorContentScale(pMonitor, (float*) &xScale, (float*) &yScale);
+        float xScale, yScale;
+        glfwGetMonitorContentScale(pMonitor, &xScale, &yScale);
 
         ret = caml_alloc(2 * Double_wosize, Double_array_tag);
         Store_double_field(ret, 0, xScale);

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -241,7 +241,7 @@ extern "C" {
     caml_glfwGetClipboardString(value vWindow) {
         CAMLparam1(vWindow);
         CAMLlocal1(ret);
-        
+
         WindowInfo *pWinInfo = (WindowInfo *)vWindow;
         GLFWwindow *wd = pWinInfo->pWindow;
 
@@ -295,7 +295,7 @@ extern "C" {
       int h = Int_val(iHeight);
       char *s = String_val(sTitle);
 
-      /* 
+      /*
       vSharedContext is an optional labeled argument in OCaml
       Depending on the value of vSharedContext we create a normal window if is none
       or a window with shared context https://www.glfw.org/docs/latest/context_guide.html#context_sharing if the value exists
@@ -615,6 +615,40 @@ extern "C" {
         ret = caml_alloc(2, 0);
         Store_field(ret, 0, Val_int(width));
         Store_field(ret, 1, Val_int(height));
+
+        CAMLreturn(ret);
+    }
+
+    CAMLprim value
+    caml_glfwGetWindowContentScale(value vWindow)
+    {
+        CAMLparam1(vWindow);
+        CAMLlocal1(ret);
+        WindowInfo* pWindowInfo = (WindowInfo *)vWindow;
+
+        float xScale, yScale;
+        glfwGetWindowContentScale(pWindowInfo->pWindow, &xScale, &yScale);
+
+        ret = caml_alloc(2, 0);
+        Store_field(ret, 0, Val_int(xScale));
+        Store_field(ret, 1, Val_int(yScale));
+
+        CAMLreturn(ret);
+    }
+
+    CAMLprim value
+    caml_glfwGetMonitorContentScale(value vMonitor)
+    {
+        CAMLparam1(vMonitor);
+        CAMLlocal1(ret);
+        GLFWmonitor* pMonitor = (GLFWmonitor*)vMonitor;
+
+        float xScale, yScale;
+        glfwGetMonitorContentScale(pMonitor, &xScale, &yScale);
+
+        ret = caml_alloc(2, 0);
+        Store_field(ret, 0, Val_int(xScale));
+        Store_field(ret, 1, Val_int(yScale));
 
         CAMLreturn(ret);
     }

--- a/src/glfw_wrapper.cpp
+++ b/src/glfw_wrapper.cpp
@@ -626,12 +626,12 @@ extern "C" {
         CAMLlocal1(ret);
         WindowInfo* pWindowInfo = (WindowInfo *)vWindow;
 
-        float xScale, yScale;
-        glfwGetWindowContentScale(pWindowInfo->pWindow, &xScale, &yScale);
+        double xScale, yScale;
+        glfwGetWindowContentScale(pWindowInfo->pWindow, (float*) &xScale, (float*) &yScale);
 
-        ret = caml_alloc(2, 0);
-        Store_field(ret, 0, Val_int(xScale));
-        Store_field(ret, 1, Val_int(yScale));
+        ret = caml_alloc(2 * Double_wosize, Double_array_tag);
+        Store_double_field(ret, 0, xScale);
+        Store_double_field(ret, 1, yScale);
 
         CAMLreturn(ret);
     }
@@ -643,12 +643,12 @@ extern "C" {
         CAMLlocal1(ret);
         GLFWmonitor* pMonitor = (GLFWmonitor*)vMonitor;
 
-        float xScale, yScale;
-        glfwGetMonitorContentScale(pMonitor, &xScale, &yScale);
+        double xScale, yScale;
+        glfwGetMonitorContentScale(pMonitor, (float*) &xScale, (float*) &yScale);
 
-        ret = caml_alloc(2, 0);
-        Store_field(ret, 0, Val_int(xScale));
-        Store_field(ret, 1, Val_int(yScale));
+        ret = caml_alloc(2 * Double_wosize, Double_array_tag);
+        Store_double_field(ret, 0, xScale);
+        Store_double_field(ret, 1, yScale);
 
         CAMLreturn(ret);
     }


### PR DESCRIPTION
Start to hook up the basics of GLFW scaling support.

I'm still working to understand the values that this function returns, but its hooked up now at least.
I've not updated the `package.json` yet (I'm using `link` locally), but can do if / when the `esy-glfw` changes are merged.

Other things that could be useful: ` glfwSetWindowContentScaleCallback` which lets you set a callback for when the scale changes, and `GLFW_SCALE_TO_MONITOR`window hint which enables auto-resize of a window by the content scale of the monitor the window is on.

