### PR TITLE
[WIP] Fill in dune-project file

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,18 @@
-(lang dune 1.1)
+(lang dune 1.11)
+(using fmt 1.2)
+(name reglfw)
+(generate_opam_files true)
+
+(source (github revery-ui/reason-glfw))
+(authors "Bryan Phelps")
+(maintainers "Bryan Phelps <bryphe@outlook.com>")
+(license MIT)
+
+(package
+  (name reglfw)
+  (synopsis "Cross-platform Reason / OCaml bindings for GLFW")
+  (description "")
+  (depends
+    (ocaml (>= <TODO: FILL VERSION HERE>))
+    (dune (>= 1.11))
+ )


### PR DESCRIPTION
A few things need to be filled in before this is ready for merge:

* The `description` part of the `(package` section.
* The `depends` part of the `(package` section. I'm not sure what version of OCaml should used, so I've left it as `(ocaml (>= <FILL VERSION HERE>))`. If anyone knows the version that should be used, let me know and I'll update this. Also, any other dependencies will need to be put here, which don't necessarily have to have versions associated with them but should be listed.

If I'm forgetting any other fields (or if there are any other changes that should be made), let me know. Note that I've used https://github.com/rgrinberg/opium/blob/master/dune-project as a reference here.

The reason for this addition is so that Revery can be published on OPAM (see https://github.com/revery-ui/revery/issues/71), which will require that its dependencies be published on OPAM as well (this repository was mentioned as a dependency of Revery in https://github.com/revery-ui/revery/issues/71#issuecomment-441527371). With this PR, the `dune-project` file will now generate `reglfw.opam` (due to `(generate_opam_files true)`), preparing this library for publishing on OPAM.